### PR TITLE
possible workaround for openmpi vader shared memory errors

### DIFF
--- a/scripts/test-cpu-tests.sh
+++ b/scripts/test-cpu-tests.sh
@@ -15,8 +15,13 @@ export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot_cpu"
 export JULIA_CUDA_USE_BINARYBUILDER=false
 export JULIA_NUM_THREADS=4
 export OPENBLAS_NUM_THREADS=1
+
 export CLIMATEMACHINE_SETTINGS_DISABLE_GPU=true
 export CLIMATEMACHINE_SETTINGS_FIX_RNG_SEED=true
+
+# workaround for vader shared memory transport permissions errors
+# we explicitily don't include the btl transport sm module here
+export OMPI_MCA_btl="self,tcp"
 
 module purge
 module load julia/1.4.2 openmpi/4.0.3 hdf5/1.10.1 netcdf-c/4.6.1

--- a/scripts/test-cpu.sh
+++ b/scripts/test-cpu.sh
@@ -18,6 +18,10 @@ export CLIMATEMACHINE_SETTINGS_DISABLE_GPU=true
 export CLIMATEMACHINE_SETTINGS_FIX_RNG_SEED=true
 export CLIMATEMACHINE_SETTINGS_OUTPUT_DIR="${CI_OUTDIR}/${SLURM_JOB_ID}_output"
 
+# workaround for vader shared memory transport permissions errors
+# we explicitily don't include the btl transport sm module here
+export OMPI_MCA_btl="self,tcp"
+
 module purge
 module load julia/1.4.2 openmpi/4.0.3 hdf5/1.10.1 netcdf-c/4.6.1
 

--- a/scripts/test-gpu-tests.sh
+++ b/scripts/test-gpu-tests.sh
@@ -14,7 +14,12 @@ cd ${CI_SRCDIR}
 export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot_gpu"
 export JULIA_CUDA_USE_BINARYBUILDER=false
 export OPENBLAS_NUM_THREADS=1
+
 export CLIMATEMACHINE_SETTINGS_FIX_RNG_SEED=true
+
+# workaround for vader shared memory transport permissions errors
+# we explicitily don't include the btl transport sm module here
+export OMPI_MCA_btl="self,tcp"
 
 module purge
 module load julia/1.4.2 cuda/10.0 openmpi/4.0.3_cuda-10.0 hdf5/1.10.1 netcdf-c/4.6.1

--- a/scripts/test-gpu.sh
+++ b/scripts/test-gpu.sh
@@ -15,8 +15,13 @@ export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot_gpu"
 export JULIA_CUDA_USE_BINARYBUILDER=false
 export JULIA_MPI_BINARY=system
 export OPENBLAS_NUM_THREADS=1
+
 export CLIMATEMACHINE_SETTINGS_FIX_RNG_SEED=true
 export CLIMATEMACHINE_SETTINGS_OUTPUT_DIR="${CI_OUTDIR}/${SLURM_JOB_ID}_output"
+
+# workaround for vader shared memory transport permissions errors
+# we explicitily don't include the btl transport sm module here
+export OMPI_MCA_btl="self,tcp"
 
 module purge
 module load julia/1.4.2 cuda/10.0 openmpi/4.0.3_cuda-10.0 hdf5/1.10.1 netcdf-c/4.6.1


### PR DESCRIPTION
 turn off btl sm transport